### PR TITLE
This commit fixes a bug in the progress bar calculation for the signa…

### DIFF
--- a/src/logic/signature.py
+++ b/src/logic/signature.py
@@ -36,9 +36,8 @@ class SignatureProcessor:
             # Pre-calculate total steps for the progress bar
             excel_path = self.config.firma_excel_dir.get()
             excel_files = [f for f in os.listdir(excel_path) if f.lower().endswith(('.xlsx', '.xls', '.xlsm')) and not f.startswith('~')]
-            pdf_path = self.config.firma_pdf_dir.get()
-            pdf_files = [f for f in os.listdir(pdf_path) if f.lower().endswith('.pdf')]
-            total_steps = len(excel_files) + len(pdf_files)
+            # The number of PDFs to compress will be the same as the number of excel files processed.
+            total_steps = len(excel_files) * 2
             self.gui.after(0, self.setup_progress, total_steps)
 
             self.logger("--- FASE 1: Elaborazione Excel e Conversione PDF ---", 'HEADER')
@@ -82,7 +81,6 @@ class SignatureProcessor:
             return True
 
         self.logger(f"Inizio elaborazione di {len(excel_files)} file Excel...")
-
         errors = []
         with ExcelHandler(self.logger) as excel:
             if not excel:


### PR DESCRIPTION
…ture and compression process.

The previous logic incorrectly calculated the total number of steps by counting the number of existing PDF files before they were created. This caused the progress bar to reach 100% prematurely and then exceed it during the compression phase.

The logic has been corrected to calculate the total steps as `(number of Excel files) * 2`, which accurately accounts for both the file processing step and the file compression step for each document. This ensures the progress bar now correctly displays the total progress from 0% to 100% across the entire operation.